### PR TITLE
Fix platform_code mapping

### DIFF
--- a/src/main/java/org/entur/netex/gtfs/export/producer/DefaultStopProducer.java
+++ b/src/main/java/org/entur/netex/gtfs/export/producer/DefaultStopProducer.java
@@ -88,9 +88,6 @@ public class DefaultStopProducer implements StopProducer {
     ) {
       stop.setDesc(stopPlace.getDescription().getValue());
     }
-    if (stopPlace.getPrivateCode() != null) {
-      stop.setPlatformCode(stopPlace.getPrivateCode().getValue());
-    }
 
     // latitude and longitude
     stop.setLon(
@@ -175,8 +172,8 @@ public class DefaultStopProducer implements StopProducer {
     ) {
       stop.setDesc(quay.getDescription().getValue());
     }
-    if (quay.getPrivateCode() != null) {
-      stop.setPlatformCode(quay.getPrivateCode().getValue());
+    if (quay.getPublicCode() != null) {
+      stop.setPlatformCode(quay.getPublicCode());
     }
 
     // latitude and longitude


### PR DESCRIPTION
The appropriate mapping for the GTFS field `platform_code`:

> Platform identifier for a platform stop (a stop belonging to a station). This should be just the platform identifier (eg. "G" or "3").

on a NeTEx Quay is the NeTEx field `publicCode`:

> A public code for a Quay, usually linked to a physical sign with a letter or number for the platform/track."

not the `privateCode`:

> Internal code or information not to be presented to the public.


 The field platform_code does not apply for a StopPlace, it should be null.