### PR TITLE
chore(deps): update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,18 +19,18 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Copy maven settings
         run: |
           wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings_release_maven_central.xml -O .github/workflows/settings.xml
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21.0.5+11
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -57,7 +57,7 @@ jobs:
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.0
         with:
           path: target/*.jar
   publish-release:


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/setup-java` from v4 to v5
- Update `actions/cache` from v4 to v5
- Update `actions/upload-artifact` from v4.6.2 to v7.0.0

Combines Renovate PRs #378, #392, #395, #398.

## Test plan
- [ ] Verify CI workflow runs successfully with updated actions