### PR TITLE
fix: tolerate non-contiguous StopPointInJourneyPattern order in shape distance lookup (#425)

### DIFF
--- a/src/main/java/org/entur/netex/gtfs/export/model/GtfsShape.java
+++ b/src/main/java/org/entur/netex/gtfs/export/model/GtfsShape.java
@@ -19,6 +19,8 @@
 package org.entur.netex.gtfs.export.model;
 
 import java.util.List;
+import java.util.Map;
+import org.entur.netex.gtfs.export.exception.GtfsExportException;
 import org.onebusaway.gtfs.model.ShapePoint;
 
 /**
@@ -29,16 +31,16 @@ public class GtfsShape {
 
   private final String id;
   private final List<ShapePoint> shapePoints;
-  private final List<Double> travelledDistanceToStop;
+  private final Map<Integer, Double> distanceTravelledByStopOrder;
 
   public GtfsShape(
     String id,
     List<ShapePoint> shapePoints,
-    List<Double> travelledDistanceToStop
+    Map<Integer, Double> distanceTravelledByStopOrder
   ) {
     this.id = id;
     this.shapePoints = shapePoints;
-    this.travelledDistanceToStop = travelledDistanceToStop;
+    this.distanceTravelledByStopOrder = distanceTravelledByStopOrder;
   }
 
   public String getId() {
@@ -50,12 +52,20 @@ public class GtfsShape {
   }
 
   /**
-   * Return the distance travelled on the shape from the start to the stop number i.
-   * The distance travelled to stop number 1 is 0 meters.
-   * @param i sequence number of the stop in the JourneyPattern, starting at 1.
-   * @return the distance travelled on the shape from the start to the stop number i, in meters.
+   * Return the distance travelled on the shape from the start to the stop with the given order.
+   * The distance travelled to the first stop in the JourneyPattern is 0 meters.
+   * The lookup is keyed by the NeTEx {@code order} value of the StopPointInJourneyPattern, which is
+   * not required to start at 1 or to be gap-free.
+   * @param order the NeTEx order of the stop in the JourneyPattern.
+   * @return the distance travelled on the shape from the start to this stop, in meters.
    */
-  public double getDistanceTravelledToStop(int i) {
-    return travelledDistanceToStop.get(i - 1);
+  public double getDistanceTravelledToStop(int order) {
+    Double distance = distanceTravelledByStopOrder.get(order);
+    if (distance == null) {
+      throw new GtfsExportException(
+        "No travelled distance for stop order " + order + " in shape " + id
+      );
+    }
+    return distance;
   }
 }

--- a/src/main/java/org/entur/netex/gtfs/export/producer/DefaultShapeProducer.java
+++ b/src/main/java/org/entur/netex/gtfs/export/producer/DefaultShapeProducer.java
@@ -22,7 +22,9 @@ import jakarta.xml.bind.JAXBElement;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.entur.netex.gtfs.export.exception.GtfsExportException;
 import org.entur.netex.gtfs.export.model.GtfsShape;
 import org.entur.netex.gtfs.export.repository.GtfsDatasetRepository;
@@ -36,6 +38,7 @@ import org.onebusaway.gtfs.model.ShapePoint;
 import org.rutebanken.netex.model.JourneyPattern;
 import org.rutebanken.netex.model.LinkInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.LinkSequenceProjection;
+import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.Projections_RelStructure;
 import org.rutebanken.netex.model.ServiceLink;
 import org.rutebanken.netex.model.ServiceLinkInJourneyPattern_VersionedChildStructure;
@@ -156,7 +159,28 @@ public class DefaultShapeProducer implements ShapeProducer {
       }
       travelledDistanceToStop.add((double) Math.round(distanceFromStart));
     }
-    return new GtfsShape(shapeId, shapePoints, travelledDistanceToStop);
+
+    // The cumulative distances above are produced in ascending "order" of the service links, i.e. in
+    // the same order as the stops sorted ascending by their "order" property. Map each cumulative
+    // distance to the corresponding stop "order" value, which is not required to start at 1 or to be
+    // gap-free within a JourneyPattern.
+    List<Integer> sortedStopOrders = journeyPattern
+      .getPointsInSequence()
+      .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()
+      .stream()
+      .map(PointInLinkSequence_VersionedChildStructure::getOrder)
+      .sorted()
+      .map(BigInteger::intValueExact)
+      .toList();
+    Map<Integer, Double> distanceTravelledByStopOrder = new HashMap<>();
+    for (int i = 0; i < sortedStopOrders.size(); i++) {
+      distanceTravelledByStopOrder.put(
+        sortedStopOrders.get(i),
+        travelledDistanceToStop.get(i)
+      );
+    }
+
+    return new GtfsShape(shapeId, shapePoints, distanceTravelledByStopOrder);
   }
 
   /**

--- a/src/test/java/org/entur/netex/gtfs/export/producer/ShapeProducerTest.java
+++ b/src/test/java/org/entur/netex/gtfs/export/producer/ShapeProducerTest.java
@@ -76,7 +76,6 @@ import org.rutebanken.netex.model.JourneyPattern;
 import org.rutebanken.netex.model.LinkSequenceProjection;
 import org.rutebanken.netex.model.LinksInJourneyPattern_RelStructure;
 import org.rutebanken.netex.model.ObjectFactory;
-import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.PointsInJourneyPattern_RelStructure;
 import org.rutebanken.netex.model.Projections_RelStructure;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
@@ -128,7 +127,7 @@ class ShapeProducerTest {
       netexDatasetRepository,
       gtfsDatasetRepository
     );
-    GtfsShape shape = shapeProducer.produce(createTestJourneyPattern());
+    GtfsShape shape = shapeProducer.produce(createTestJourneyPattern(1, 2, 3));
     Assertions.assertNotNull(shape);
     Assertions.assertEquals(4, shape.getShapePoints().size());
 
@@ -161,6 +160,86 @@ class ShapeProducerTest {
     );
   }
 
+  /**
+   * Regression test for issue #425: the StopPointInJourneyPattern "order" values do not start at 1.
+   * The distance lookup must be keyed by the "order" value, not by its position, so a pattern with
+   * stop orders [7, 8, 9] must convert without throwing and resolve distances per order.
+   */
+  @Test
+  void testShapeProducerWithNonOneStartingOrder() {
+    GtfsShape shape = produceShape(7, 8, 9);
+
+    double serviceLinkLength1 =
+      GeometryUtil.distance(A1, A2) + GeometryUtil.distance(A2, A3);
+    double serviceLinkLength2 = GeometryUtil.distance(A3, A4);
+
+    Assertions.assertEquals(0, shape.getDistanceTravelledToStop(7));
+    Assertions.assertEquals(
+      Math.round(serviceLinkLength1),
+      shape.getDistanceTravelledToStop(8)
+    );
+    Assertions.assertEquals(
+      Math.round(serviceLinkLength1 + serviceLinkLength2),
+      shape.getDistanceTravelledToStop(9)
+    );
+    // monotonically increasing
+    Assertions.assertTrue(
+      shape.getDistanceTravelledToStop(7) <= shape.getDistanceTravelledToStop(8)
+    );
+    Assertions.assertTrue(
+      shape.getDistanceTravelledToStop(8) <= shape.getDistanceTravelledToStop(9)
+    );
+  }
+
+  /**
+   * Regression test for issue #425: the StopPointInJourneyPattern "order" values contain gaps.
+   * A pattern with stop orders [1, 3, 5] must convert without throwing and resolve distances per
+   * order value.
+   */
+  @Test
+  void testShapeProducerWithGappedOrder() {
+    GtfsShape shape = produceShape(1, 3, 5);
+
+    double serviceLinkLength1 =
+      GeometryUtil.distance(A1, A2) + GeometryUtil.distance(A2, A3);
+    double serviceLinkLength2 = GeometryUtil.distance(A3, A4);
+
+    Assertions.assertEquals(0, shape.getDistanceTravelledToStop(1));
+    Assertions.assertEquals(
+      Math.round(serviceLinkLength1),
+      shape.getDistanceTravelledToStop(3)
+    );
+    Assertions.assertEquals(
+      Math.round(serviceLinkLength1 + serviceLinkLength2),
+      shape.getDistanceTravelledToStop(5)
+    );
+  }
+
+  private static GtfsShape produceShape(int... stopOrders) {
+    NetexDatasetRepository netexDatasetRepository = mock(
+      NetexDatasetRepository.class
+    );
+    when(netexDatasetRepository.getServiceLinkById(TEST_SERVICE_LINK_1))
+      .thenReturn(createServiceLink(A1.y, A1.x, A2.y, A2.x, A3.y, A3.x));
+    when(netexDatasetRepository.getServiceLinkById(TEST_SERVICE_LINK_2))
+      .thenReturn(createServiceLink(A3.y, A3.x, A4.y, A4.x));
+
+    GtfsDatasetRepository gtfsDatasetRepository = mock(
+      GtfsDatasetRepository.class
+    );
+    when(gtfsDatasetRepository.getDefaultAgency()).thenReturn(new Agency());
+
+    ShapeProducer shapeProducer = new DefaultShapeProducer(
+      netexDatasetRepository,
+      gtfsDatasetRepository
+    );
+    GtfsShape shape = shapeProducer.produce(
+      createTestJourneyPattern(stopOrders)
+    );
+    Assertions.assertNotNull(shape);
+    return shape;
+  }
+
   private static ServiceLink createServiceLink(double... coordinates) {
     List<Double> coordinateList = Arrays.asList(
       ArrayUtils.toObject(coordinates)
@@ -189,32 +268,26 @@ class ShapeProducerTest {
     return serviceLink;
   }
 
-  private static JourneyPattern createTestJourneyPattern() {
+  private static JourneyPattern createTestJourneyPattern(int... stopOrders) {
     JourneyPattern journeyPattern = new JourneyPattern();
 
     PointsInJourneyPattern_RelStructure pointInSequences =
       new PointsInJourneyPattern_RelStructure();
-    StopPointInJourneyPattern pointLinkInSequence1 =
-      new StopPointInJourneyPattern();
-    ScheduledStopPointRefStructure scheduledStopPointRefStructure =
-      NETEX_FACTORY.createScheduledStopPointRefStructure();
-
-    JAXBElement<ScheduledStopPointRefStructure> scheduledStopPointRef =
-      NETEX_FACTORY.createScheduledStopPointRef(scheduledStopPointRefStructure);
-    pointLinkInSequence1.setScheduledStopPointRef(scheduledStopPointRef);
-    pointInSequences
-      .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()
-      .add(0, pointLinkInSequence1);
-    PointInLinkSequence_VersionedChildStructure pointLinkInSequence2 =
-      new StopPointInJourneyPattern();
-    pointInSequences
-      .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()
-      .add(1, pointLinkInSequence2);
-    PointInLinkSequence_VersionedChildStructure pointLinkInSequence3 =
-      new StopPointInJourneyPattern();
-    pointInSequences
-      .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()
-      .add(2, pointLinkInSequence3);
+    for (int i = 0; i < stopOrders.length; i++) {
+      StopPointInJourneyPattern stopPointInJourneyPattern =
+        new StopPointInJourneyPattern();
+      ScheduledStopPointRefStructure scheduledStopPointRefStructure =
+        NETEX_FACTORY.createScheduledStopPointRefStructure();
+      JAXBElement<ScheduledStopPointRefStructure> scheduledStopPointRef =
+        NETEX_FACTORY.createScheduledStopPointRef(
+          scheduledStopPointRefStructure
+        );
+      stopPointInJourneyPattern.setScheduledStopPointRef(scheduledStopPointRef);
+      stopPointInJourneyPattern.setOrder(BigInteger.valueOf(stopOrders[i]));
+      pointInSequences
+        .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern()
+        .add(i, stopPointInJourneyPattern);
+    }
     journeyPattern.setPointsInSequence(pointInSequences);
 
     LinksInJourneyPattern_RelStructure linksInJourneyPatternRelStructure =

--- a/src/test/java/org/entur/netex/gtfs/export/producer/StopTimeProducerTest.java
+++ b/src/test/java/org/entur/netex/gtfs/export/producer/StopTimeProducerTest.java
@@ -61,6 +61,7 @@ import jakarta.xml.bind.JAXBElement;
 import java.math.BigInteger;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Map;
 import org.entur.netex.gtfs.export.model.GtfsShape;
 import org.entur.netex.gtfs.export.repository.GtfsDatasetRepository;
 import org.entur.netex.gtfs.export.repository.NetexDatasetRepository;
@@ -124,11 +125,7 @@ class StopTimeProducerTest {
       TEST_STOP_POINT_IN_JOURNEY_PATTERN_ID_1
     );
     Trip trip = new Trip();
-    GtfsShape gtfsShape = new GtfsShape(
-      "id",
-      new ArrayList<>(),
-      new ArrayList<>()
-    );
+    GtfsShape gtfsShape = new GtfsShape("id", new ArrayList<>(), Map.of());
     StopTime stopTime = stopTimeProducer.produce(
       timetabledPassingTime,
       journeyPattern,
@@ -179,11 +176,7 @@ class StopTimeProducerTest {
       TEST_STOP_POINT_IN_JOURNEY_PATTERN_ID_1
     );
     Trip trip = new Trip();
-    GtfsShape gtfsShape = new GtfsShape(
-      "id",
-      new ArrayList<>(),
-      new ArrayList<>()
-    );
+    GtfsShape gtfsShape = new GtfsShape("id", new ArrayList<>(), Map.of());
     StopTime stopTime = stopTimeProducer.produce(
       timetabledPassingTime,
       journeyPattern,
@@ -234,11 +227,7 @@ class StopTimeProducerTest {
       null
     );
     Trip trip = new Trip();
-    GtfsShape gtfsShape = new GtfsShape(
-      "id",
-      new ArrayList<>(),
-      new ArrayList<>()
-    );
+    GtfsShape gtfsShape = new GtfsShape("id", new ArrayList<>(), Map.of());
     StopTime stopTime = stopTimeProducer.produce(
       timetabledPassingTime,
       journeyPattern,
@@ -291,11 +280,7 @@ class StopTimeProducerTest {
       Boolean.FALSE
     );
     Trip trip = new Trip();
-    GtfsShape gtfsShape = new GtfsShape(
-      "id",
-      new ArrayList<>(),
-      new ArrayList<>()
-    );
+    GtfsShape gtfsShape = new GtfsShape("id", new ArrayList<>(), Map.of());
     StopTime stopTime = stopTimeProducer.produce(
       timetabledPassingTime,
       journeyPattern,


### PR DESCRIPTION
## Summary

Fixes #425.

`IndexOutOfBoundsException` was thrown during timetable conversion when a `JourneyPattern`'s `StopPointInJourneyPattern.order` values did not run `1..N` contiguously (e.g. a 3-stop pattern with orders `7, 8, 9`, as emitted by real Flytoget `FLT` NeTEx).

The shape distance machinery builds a **positional** distance list (one entry per stop, indexed by rank), but the lookup used the raw NeTEx `order` value as a 1-based index (`order - 1`). Any `order` greater than the number of stops overran the list.

## Fix

Decouple the distance lookup from the absolute `order` value by keying the distance on the stop's `order` value:

- **`GtfsShape`** now stores a `Map<Integer, Double>` (order → metres) instead of a positional `List<Double>`. `getDistanceTravelledToStop(int order)` resolves via the map and throws a descriptive `GtfsExportException` when an order has no matching distance, instead of a raw `IndexOutOfBoundsException`.
- **`DefaultShapeProducer`** builds the map by zipping the order-sorted cumulative distances with the order-sorted stop points.
- **`DefaultStopTimeProducer`** is unchanged — it already passes the raw `order`, now a lookup *by value*, tolerant of any start offset and gaps. `stop_sequence` keeps using the raw `order` (GTFS permits non-contiguous, increasing sequences).

## Tests

- Updated existing `ShapeProducerTest` / `StopTimeProducerTest` for the new `GtfsShape` shape.
- Added regression tests: non-1 start `[7, 8, 9]` (the reported case) and gapped `[1, 3, 5]`, asserting no throw, first-stop distance `0.0`, and monotonic increase.

All 65 tests pass.